### PR TITLE
[v4.1.0] Add `/dm` Slash Command & Bug Fixes

### DIFF
--- a/common/CommonStrings.py
+++ b/common/CommonStrings.py
@@ -1,19 +1,19 @@
 """CommonStrings.py
 
 Collection of commonly used public static final strings and related functions.
-Date: 10/18/2023
+Date: 10/22/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
 
-BOT_ICON_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/icon.png"
+BOT_ICON_URL = "https://raw.githubusercontent.com/Project-Backstab/BF2MC-DiscordBot/main/assets/icon.png"
 COUNTRY_FLAGS_URL = "https://flagcdn.com/w40/<code>.png"
 LANG_FLAGS_URL = "https://www.unknown.nu/flags/images/<code>-100"
-GM_THUMBNAILS_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/gamemode_thumbnails/<gamemode>.png"
-MAP_IMAGES_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/map_images/<map_name>.png"
+GM_THUMBNAILS_URL = "https://raw.githubusercontent.com/Project-Backstab/BF2MC-DiscordBot/main/assets/gamemode_thumbnails/<gamemode>.png"
+MAP_IMAGES_URL = "https://raw.githubusercontent.com/Project-Backstab/BF2MC-DiscordBot/main/assets/map_images/<map_name>.png"
 RANK_IMAGES_URL = "https://raw.githubusercontent.com/Project-Backstab/BF2MC-DiscordBot/main/assets/rank_images/rank<rank_id>.png"
-CLAN_THUMB_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/clan_images/thumbnail.png"
-CLAN_REGION_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/clan_images/<region>.png"
+CLAN_THUMB_URL = "https://raw.githubusercontent.com/Project-Backstab/BF2MC-DiscordBot/main/assets/clan_images/thumbnail.png"
+CLAN_REGION_URL = "https://raw.githubusercontent.com/Project-Backstab/BF2MC-DiscordBot/main/assets/clan_images/<region>.png"
 STATUS_STRINGS = {
     "online":   "SERVERS: ONLINE 🟢",
     "offline":  "SERVERS: OFFLINE 🔴",

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 10/20/2023
+Date: 10/22/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -19,7 +19,7 @@ from src import BackstabBot
 import common.CommonStrings as CS
 
 def main():
-    VERSION = "4.0.4"
+    VERSION = "4.1.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogServerStatus",
@@ -184,6 +184,64 @@ def main():
         await ctx.send(text)
         await ctx.respond("...", ephemeral=True, delete_after=0)
         bot.log(f"{ctx.author.name} made bot say \"{text}\"")
+        
+    @bot.slash_command(guild_ids=[bot.config['GuildID']], name = "dm", description="Makes the bot send a Direct Message to a member. Only admins can do this.")
+    @discord.default_permissions(manage_channels=True) # Only members with Manage Channels permission can use this command.
+    async def dm(
+        ctx, 
+        member: discord.Option(
+            discord.Member, 
+            description="Discord member to send DM to",
+            required=True
+        ), 
+        title: discord.Option(
+            str, 
+            description="Title of message",
+            required=True
+        ), 
+        color: discord.Option(
+            str, 
+            description="Accent color of message",
+            choices=[
+                "Blurple",
+                "Green",
+                "Yellow",
+                "Red"
+            ],
+            required=True
+        ), 
+        message: discord.Option(
+            str, 
+            description="Message text",
+            required=True
+        )
+    ):
+        """Slash Command: /dm
+        
+        Makes the bot send a Direct Message to a member. Only admins can do this.
+        """
+        # Determine color
+        _embed_color = discord.Colour.blurple()
+        if color == "Green": _embed_color = discord.Colour.green()
+        elif color == "Yellow": _embed_color = discord.Colour.yellow()
+        elif color == "Red": _embed_color = discord.Colour.red()
+        # Build embed for message
+        _embed = discord.Embed(
+            title=title,
+            description=message,
+            color=_embed_color
+        )
+        _embed.set_author(
+            name="BFMCspy Admin Team", 
+            icon_url="https://raw.githubusercontent.com/Project-Backstab/BF2MC-DiscordBot/main/assets/emojis/patches/BFMCspy_Launch.png"
+        )
+        _footer = "Do not reply to this message; it will not be read."
+        _footer += "\nPlease contact an admin directly if you wish to reply."
+        _embed.set_footer(text=_footer)
+        # Send message
+        await member.send(embed=_embed)
+        await ctx.respond("Message sent.", ephemeral=True)
+        bot.log(f'{ctx.author.name} made bot send the following message to {member.name}:\n\tTitle: {title}\n\tMessage: "{message}"')
         
     @bot.slash_command(guild_ids=[bot.config['GuildID']], name = "reloadconfig", description="Reloads the bot's config file. Only admins can do this.")
     @discord.default_permissions(manage_channels=True) # Only members with Manage Channels permission can use this command.

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,7 +1,7 @@
 """bot.py
 
 A subclass of `discord.Bot` that adds ease-of-use instance variables and functions (e.g. database object).
-Date: 10/19/2023
+Date: 10/22/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -215,11 +215,14 @@ class BackstabBot(discord.Bot):
         # Get team players and sort by score
         _team1 = []
         _team2 = []
+        _no_team = []
         for _p in server_data['players']:
             if _p['team'] == 0:
                 _team1.append(_p)
-            else:
+            elif _p['team'] == 1:
                 _team2.append(_p)
+            else:
+                _no_team.append(_p)
         _team1 = sorted(_team1, key=lambda x: x['score'], reverse=True)
         _team2 = sorted(_team2, key=lambda x: x['score'], reverse=True)
         
@@ -243,7 +246,7 @@ class BackstabBot(discord.Bot):
             value=self.get_team_score_str(server_data['gametype'], server_data['score0']), 
             inline=False
         )
-        _embed.add_field(name="Player:", value=self.get_player_attr_list_str(_team1, 'name'), inline=True)
+        _embed.add_field(name="Players:", value=self.get_player_attr_list_str(_team1, 'name'), inline=True)
         _embed.add_field(name="Score:", value=self.get_player_attr_list_str(_team1, 'score'), inline=True)
         _embed.add_field(name="Deaths:", value=self.get_player_attr_list_str(_team1, 'deaths'), inline=True)
         _embed.add_field(
@@ -251,9 +254,16 @@ class BackstabBot(discord.Bot):
             value=self.get_team_score_str(server_data['gametype'], server_data['score1']), 
             inline=False
         )
-        _embed.add_field(name="Player:", value=self.get_player_attr_list_str(_team2, 'name'), inline=True)
+        _embed.add_field(name="Players:", value=self.get_player_attr_list_str(_team2, 'name'), inline=True)
         _embed.add_field(name="Score:", value=self.get_player_attr_list_str(_team2, 'score'), inline=True)
         _embed.add_field(name="Deaths:", value=self.get_player_attr_list_str(_team2, 'deaths'), inline=True)
+        if len(_no_team) > 0:
+            _embed.add_field(
+                name="👥︎  No Team:",  
+                value="", 
+                inline=False
+            )
+            _embed.add_field(name="Players:", value=self.get_player_attr_list_str(_no_team, 'name'), inline=True)
         _embed.set_image(url=CS.MAP_IMAGES_URL.replace("<map_name>", server_data['map']))
         _embed.set_footer(text=f"Data fetched at: {self.last_query.strftime('%I:%M:%S %p UTC')} -- {self.config['API']['HumanURL']}")
 


### PR DESCRIPTION
- Added `/dm` Slash Command to send formal generic messages from the admin team to a member.
- Updated the version number.
- Fixed CommonStrings using old repository image links.
- Fixes no-team-selected players from being displayed in team 2 in the server status, and now displays them as a separate list.