### PR TITLE
[v4.2.0] Improve Server Stats Reporting

### DIFF
--- a/common/CommonStrings.py
+++ b/common/CommonStrings.py
@@ -1,7 +1,7 @@
 """CommonStrings.py
 
 Collection of commonly used public static final strings and related functions.
-Date: 10/25/2023
+Date: 01/12/2024
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -31,14 +31,14 @@ TEAM_STRINGS = {
 }
 MAP_STRINGS = (
     "Backstab",
-    "Bridge Too Far",
-    "Cold Front",
-    "Dammage",
     "Deadly Pass",
+    "Bridge Too Far",
+    "Dammage",
     "Harbor Edge",
     "Honor",
     "Little Big Eye",
     "Missile Crisis",
+    "Cold Front",
     "Russian Border",
     "Special Op",
     "The Black Gold",

--- a/config-example.cfg
+++ b/config-example.cfg
@@ -23,7 +23,7 @@
         ]
     },
     "PlayerStats": {
-        "MatchMinPlayers": 2
+        "MatchMinPlayers": 3
     },
     "Translate": {
         "Enabled": true,

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 10/27/2023
+Date: 01/12/2024
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -19,7 +19,7 @@ from src import BackstabBot
 import common.CommonStrings as CS
 
 def main():
-    VERSION = "4.1.3"
+    VERSION = "4.2.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogServerStatus",


### PR DESCRIPTION
- Fixed `/mostplayed map` reporting incorrect maps and counts due to incorrect map IDs in CommonStrings and counting empty games in the DB.
- Added comma separated thousandths in count numbers.
- Fixed `/total games` including empty games.
- Added `/total kills` Slash Command.
- Added `/total vehicles` Slash Command.
- Changed `MatchMinPlayers` in config example to 3 (to match server setting).